### PR TITLE
feat: Add sticky headers support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wamra/gantt-task-react",
-  "version": "0.6.17",
+  "version": "0.7.0",
   "description": "Interactive Gantt Chart for React with TypeScript",
   "author": "WAMRA <wamra@users.noreply.github.com>",
   "homepage": "https://github.com/wamra/gantt-task-react/blob/main/README.md#gantt-task-react",

--- a/src/components/calendar/calendar.module.css
+++ b/src/components/calendar/calendar.module.css
@@ -35,3 +35,13 @@
   stroke: #e0e0e0;
   stroke-width: 1.4;
 }
+
+.calendarMainSticky {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: white;
+  border-top: #e6e4e4 3px solid;
+  border-bottom: #e6e4e4 3px solid;
+  box-sizing: content-box;
+}

--- a/src/components/calendar/calendar.tsx
+++ b/src/components/calendar/calendar.tsx
@@ -30,6 +30,7 @@ export type CalendarProps = {
   rtl: boolean;
   startColumnIndex: number;
   colors: Partial<ColorStyles>;
+  stickyHeaders?: boolean;
 };
 
 export const Calendar: React.FC<CalendarProps> = ({
@@ -48,7 +49,8 @@ export const Calendar: React.FC<CalendarProps> = ({
   renderTopHeader = defaultRenderTopHeader,
   rtl,
   startColumnIndex,
-  colors
+  colors,
+  stickyHeaders = false
 }) => {
   const renderBottomHeaderByDate = useCallback(
     (date: Date, index: number) =>
@@ -467,7 +469,7 @@ export const Calendar: React.FC<CalendarProps> = ({
   }
 
   return (
-    <div className={styles.calendarMain} style={{ width: fullSvgWidth }}>
+    <div className={stickyHeaders ? styles.calendarMainSticky : styles.calendarMain} style={{ width: fullSvgWidth }}>
       <svg
         xmlns="http://www.w3.org/2000/svg"
         width={fullSvgWidth}

--- a/src/components/gantt/gantt.module.css
+++ b/src/components/gantt/gantt.module.css
@@ -7,6 +7,17 @@
   margin: 0;
   padding: 0;
 }
+
+.ganttTaskRootSticky {
+  display:flex;
+  flex-direction: column;
+  overflow-x: scroll;
+  overflow-y: hidden;
+  font-size: 0;
+  margin: 0;
+  padding: 0;
+  height: 100%;
+}
 /* Only chrome otherwise the firefox scrollbar has no edge*/
 @media screen and (-webkit-min-device-pixel-ratio:0) and (min-resolution:.001dpcm) {
   .ganttTaskRoot {
@@ -44,6 +55,7 @@
   overflow-x: hidden;
   overflow-y: auto;
 }
+
 /* Only chrome otherwise the firefox scrollbar has no edges*/
 @media screen and (-webkit-min-device-pixel-ratio:0) and (min-resolution:.001dpcm) {
   .ganttTaskContent {
@@ -60,4 +72,16 @@
   list-style: none;
   outline: none;
   position: relative;
+}
+
+.wrapperSticky {
+  display:grid;
+  overflow-x: hidden;
+  overflow-y: hidden;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+  outline: none;
+  position: relative;
+  height: 100%;
 }

--- a/src/components/gantt/gantt.tsx
+++ b/src/components/gantt/gantt.tsx
@@ -200,6 +200,7 @@ export const Gantt: React.FC<GanttProps> = ({
                                               isShowTaskNumbers = true,
                                               isUnknownDates = false,
                                               isAdjustToWorkingDates = true,
+                                              stickyHeaders = false,
                                               onAddTask = undefined,
                                               onAddTaskClick = undefined,
                                               onArrowDoubleClick: onArrowDoubleClickProp = undefined,
@@ -1926,7 +1927,7 @@ export const Gantt: React.FC<GanttProps> = ({
   const displayTable = !columnsProp || columnsProp.length > 0;
   return (
     <div
-      className={styles.wrapper}
+      className={stickyHeaders ? styles.wrapperSticky : styles.wrapper}
       onKeyDown={handleKeyDown}
       tabIndex={0}
       ref={wrapperRef}
@@ -1938,7 +1939,7 @@ export const Gantt: React.FC<GanttProps> = ({
       }}
     >
       {/* {columns.length > 0 && <TaskList {...tableProps} />} */}
-      {displayTable && <TaskList {...tableProps} />}
+      {displayTable && <TaskList {...tableProps} stickyHeaders={stickyHeaders} />}
 
       <TaskGantt
         barProps={barProps}
@@ -1954,6 +1955,7 @@ export const Gantt: React.FC<GanttProps> = ({
         ganttTaskRootRef={ganttTaskRootRef}
         onScrollGanttContentVertically={onScrollVertically}
         colors={colors}
+        stickyHeaders={stickyHeaders}
       />
 
       {tooltipTaskFromMap && (

--- a/src/components/gantt/task-gantt.tsx
+++ b/src/components/gantt/task-gantt.tsx
@@ -31,7 +31,8 @@ export type TaskGanttProps = {
   onScrollGanttContentVertically: (
     event: SyntheticEvent<HTMLDivElement>
   ) => void;
-  colors: Partial<ColorStyles>
+  colors: Partial<ColorStyles>;
+  stickyHeaders?: boolean;
 };
 
 const TaskGanttInner: React.FC<TaskGanttProps> = (props) => {
@@ -49,7 +50,8 @@ const TaskGanttInner: React.FC<TaskGanttProps> = (props) => {
     onVerticalScrollbarScrollX,
     ganttTaskRootRef,
     onScrollGanttContentVertically: onScrollVertically,
-    colors
+    colors,
+    stickyHeaders = false
   } = props;
   const containerStyle: CSSProperties = {
     // In order to see the vertical scrollbar of the gantt content,
@@ -182,12 +184,12 @@ const TaskGanttInner: React.FC<TaskGanttProps> = (props) => {
   };
   return (
     <div
-      className={styles.ganttTaskRoot}
+      className={stickyHeaders ? styles.ganttTaskRootSticky : styles.ganttTaskRoot}
       ref={ganttTaskRootRef}
       onScroll={onVerticalScrollbarScrollX}
       dir="ltr"
     >
-      <Calendar {...calendarProps} colors={colors} />
+      <Calendar {...calendarProps} colors={colors} stickyHeaders={stickyHeaders} />
 
       <div
         ref={ganttTaskContentRef}

--- a/src/components/task-list/task-list.module.css
+++ b/src/components/task-list/task-list.module.css
@@ -74,3 +74,44 @@
 .hidden {
   display: none;
 }
+
+.ganttTableWrapperSticky {
+  display: grid;
+  overflow: hidden;
+  grid-template-rows: auto 1fr;
+  overflow-x: auto;
+  scrollbar-width: thin;
+  height: 100%;
+}
+
+.ganttTableWrapperSticky::-webkit-scrollbar {
+  width: 1.1rem;
+  height: 1.1rem;
+}
+
+.ganttTableWrapperSticky::-webkit-scrollbar-corner {
+  background: transparent;
+}
+
+.ganttTableWrapperSticky::-webkit-scrollbar-thumb {
+  border: 6px solid transparent;
+  background: rgba(0, 0, 0, 0.2);
+  background: var(--palette-black-alpha-20, rgba(0, 0, 0, 0.2));
+  border-radius: 10px;
+  background-clip: padding-box;
+}
+
+.ganttTableWrapperSticky::-webkit-scrollbar-thumb:hover {
+  border: 4px solid transparent;
+  background: rgba(0, 0, 0, 0.3);
+  background: var(--palette-black-alpha-30, rgba(0, 0, 0, 0.3));
+  background-clip: padding-box;
+}
+
+.taskListHeaderSticky {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: white;
+  border-bottom: 1px solid #e6e4e4;
+}

--- a/src/components/task-list/task-list.tsx
+++ b/src/components/task-list/task-list.tsx
@@ -68,6 +68,7 @@ export type TaskListProps = {
   onScrollTableListContentVertically: (
     event: SyntheticEvent<HTMLDivElement>
   ) => void;
+  stickyHeaders?: boolean;
 } & TaskListHeaderActionsProps;
 
 const TaskListInner: React.FC<TaskListProps & TaskListHeaderActionsProps> = (
@@ -110,7 +111,8 @@ const TaskListInner: React.FC<TaskListProps & TaskListHeaderActionsProps> = (
     onScrollTableListContentVertically,
     onCollapseAll,
     onExpandFirstLevel,
-    onExpandAll
+    onExpandAll,
+    stickyHeaders = false
   }) => {
   // Manage the column and list table resizing
   const [
@@ -131,23 +133,40 @@ const TaskListInner: React.FC<TaskListProps & TaskListHeaderActionsProps> = (
   return (
     <div className={styles.ganttTableRoot} ref={taskListRef}>
       <div
-        className={styles.ganttTableWrapper}
+        className={stickyHeaders ? styles.ganttTableWrapperSticky : styles.ganttTableWrapper}
         style={{
           width: tableWidth
         }}
       >
-        <TaskListHeader
-          headerHeight={distances.headerHeight}
-          fontFamily={fontFamily}
-          fontSize={fontSize}
-          columns={columns}
-          onColumnResizeStart={onColumnResizeStart}
-          canResizeColumns={canResizeColumns}
-          onCollapseAll={onCollapseAll}
-          onExpandFirstLevel={onExpandFirstLevel}
-          onExpandAll={onExpandAll}
-          colors={colors}
-        />
+        {stickyHeaders ? (
+          <div className={styles.taskListHeaderSticky}>
+            <TaskListHeader
+              headerHeight={distances.headerHeight}
+              fontFamily={fontFamily}
+              fontSize={fontSize}
+              columns={columns}
+              onColumnResizeStart={onColumnResizeStart}
+              canResizeColumns={canResizeColumns}
+              onCollapseAll={onCollapseAll}
+              onExpandFirstLevel={onExpandFirstLevel}
+              onExpandAll={onExpandAll}
+              colors={colors}
+            />
+          </div>
+        ) : (
+          <TaskListHeader
+            headerHeight={distances.headerHeight}
+            fontFamily={fontFamily}
+            fontSize={fontSize}
+            columns={columns}
+            onColumnResizeStart={onColumnResizeStart}
+            canResizeColumns={canResizeColumns}
+            onCollapseAll={onCollapseAll}
+            onExpandFirstLevel={onExpandFirstLevel}
+            onExpandAll={onExpandAll}
+            colors={colors}
+          />
+        )}
 
         <div
           className={styles.taskListContent}

--- a/src/types/public-types.ts
+++ b/src/types/public-types.ts
@@ -490,6 +490,10 @@ export interface DisplayOption {
    */
   isShowCriticalPath?: boolean;
   /**
+   * Enable sticky headers that remain visible when scrolling vertically
+   */
+  stickyHeaders?: boolean;
+  /**
    * Show numbers of tasks next to tasks
    */
   isShowTaskNumbers?: boolean;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1681,10 +1681,10 @@
   resolved "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz"
   integrity sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==
 
-"@esbuild/darwin-x64@0.18.20":
+"@esbuild/darwin-arm64@0.18.20":
   version "0.18.20"
-  resolved "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz"
-  integrity sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==
+  resolved "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz"
+  integrity sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==
 
 "@eslint-community/eslint-utils@^4.2.0":
   version "4.4.1"
@@ -7265,6 +7265,11 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
+
+fsevents@^2.3.2, fsevents@~2.3.2:
+  version "2.3.3"
+  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz"
+  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
 
 function-bind@^1.1.2:
   version "1.1.2"


### PR DESCRIPTION
## Description
This PR adds sticky headers support to the Gantt chart component.

## Changes
- Added `stickyHeaders` prop to enable fixed headers when scrolling vertically
- Implemented CSS sticky positioning for both task list and calendar headers
- Headers remain visible at the top while content scrolls beneath them
- Maintains backward compatibility (defaults to false)
- Preserves existing scroll synchronization behavior
- Bumped version to 0.7.0

## Testing
- Headers stay fixed when scrolling vertically
- Horizontal scroll still syncs between headers and content
- No visual glitches or layout shifts
- Performance remains smooth with 100+ tasks

## Breaking Changes
None - this is a backward-compatible feature addition.

## Screenshots/Demo
The sticky headers feature allows users to:
1. Keep task column headers visible when scrolling through long task lists
2. Keep calendar date headers visible for better date reference
3. Improve usability when working with projects containing many tasks

Fixes issue with headers scrolling out of view in the Gantt chart.